### PR TITLE
docs: update README to use 'yarn' instead of 'yarn add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ First, clone the repository and install the dependencies:
 ```bash
 git clone https://github.com/michaelshimeles/styleui-os.git
 cd styleui-os
-yarn add
+yarn
 ```
 
 Then, run the development server:
-
+```
+yarn dev
+```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 


### PR DESCRIPTION
When using `yarn add` I have the following issue:

$ yarn add
yarn add v1.22.22
error Missing list of packages to add to your project.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.


However, using just `yarn` as it was shown in the **Next.js Starter Project Readme** works properly as it's like `yarn install`.

$ yarn
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
warning Pattern ["string-width@^4.1.0"] is trying to unpack in the same destination "C:\\Users\\NAME\\AppData\\Local\\Yarn\\Cache\\v6\\npm-string-width-cjs-4.2.3-269c7117d27b05ad2e536830a8ec895ef9c6d010-integrity\\node_modules\\string-width-cjs" as pattern ["string-width-cjs@npm:string-width@^4.2.0"]. This could result in non-deterministic behavior, skipping.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 24.17s.